### PR TITLE
兼容 x86-sciter 版客户端，此版客户端通过访问 "POST /api/ab/get" 来获取地址簿

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -9,7 +9,8 @@ from api import views
 urlpatterns = [
     url(r'^login',views.login),
     url(r'^logout',views.logout),
-    url(r'^ab',views.ab),
+    url(r'^ab$',views.ab),
+    url(r'^ab\/get',views.ab_get), # 兼容 x86-sciter 版客户端
     url(r'^users',views.users),
     url(r'^peers',views.peers),
     url(r'^currentUser',views.currentUser),

--- a/api/views_api.py
+++ b/api/views_api.py
@@ -200,6 +200,11 @@ def ab(request):
     }
     return JsonResponse(result)
 
+def ab_get(request):
+    # 兼容 x86-sciter 版客户端，此版客户端通过访问 "POST /api/ab/get" 来获取地址簿
+    request.method = 'GET'
+    return ab(request)
+
 def sysinfo(request):
     # 客户端注册服务后，才会发送设备信息
     result = {}


### PR DESCRIPTION
修复一个地址簿获取bug
```
{
    'code':102,
    'data':'更新地址簿有误'
}
```