### PR TITLE
镜像同步发布到 DockerHub

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,10 +10,9 @@ on:
     branches:
       - master
     tags:
-      - "v*.*"
+      - "v*"
 
 env:
-  REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
@@ -21,13 +20,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: |
+            ${{ env.IMAGE_NAME }}
+            ghcr.io/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -38,9 +42,15 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -58,3 +68,12 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Update repo description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAME }}
+          short-description: ${{ github.event.repository.description }}
+          enable-url-completion: true


### PR DESCRIPTION
Hi，目前 Docker 镜像是发布在 ghcr.io ，但大陆连接 ghcr.io 下载非常慢（可能以 kb 为单位）。

故希望镜像同步发布到 DockerHub，好处有：

1. 阿里云、腾讯云等基本都做了 DockerHub 镜像，可以获得很好的速度。
2. DockerHub 是一个相对官方的平台，项目可以获得更好的曝光。

本 PR 的 workflows 可以在一次构建后，同时发布到 ghcr.io 和 DockerHub，**在合并前**您需要：
1. 前往 https://hub.docker.com/ 注册同名用户，即 `kingmo888`
2. 在 https://hub.docker.com/settings/security 中生成 Access Tokens
3. 在项目 Settings 中设置 `DOCKERHUB_USERNAME` `DOCKERHUB_TOKEN` 两个变量，详细路径如图：

![image](https://github.com/kingmo888/rustdesk-api-server/assets/5239753/81c35e85-7e00-4602-a14d-57436886c003)

这两个变量用以提交镜像到 DockerHub ，可以被 Actions 读取，但不会泄露。

随后合并PR，构建完成后将自动提交到 https://hub.docker.com/r/kingmo888/rustdesk-api-server
